### PR TITLE
feat: add configurable data limit to dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
       - ./hero.db:/app/hero.db
     environment:
       - NODE_ENV=development
+      - DEV_DAYS_LIMIT=365

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,3 +3,5 @@ export const SESSION_SECRET = process.env.SESSION_SECRET!;
 export const INTRA_API_UID = process.env.INTRA_API_UID!;
 export const INTRA_API_SECRET = process.env.INTRA_API_SECRET!;
 export const CAMPUS_ID: number = parseInt(process.env.INTRA_CAMPUS_ID!);
+export const NODE_ENV = process.env.NODE_ENV || "development";
+export const DEV_DAYS_LIMIT: number = process.env.DEV_DAYS_LIMIT ? parseInt(process.env.DEV_DAYS_LIMIT) : 365;

--- a/src/intra/base.ts
+++ b/src/intra/base.ts
@@ -5,6 +5,7 @@ import { syncCursus } from "./cursus";
 import { syncProjects } from "./projects";
 import { syncProjectsUsers } from "./projects_users";
 import { syncLocations } from "./locations";
+import { DEV_DAYS_LIMIT, NODE_ENV } from "../env";
 
 export const prisma = new PrismaClient();
 
@@ -83,6 +84,15 @@ export const fetchMultiple42ApiPagesCallback = async function(api: Fast42, path:
 };
 
 export const syncData = async function(api: Fast42, syncDate: Date, lastSyncDate: Date | undefined, path: string, params: any): Promise<any[]> {
+	// In development mode we do not want to be stuck fetching too much data,
+	// so we assume a default limit of two years
+	//
+	// The only case in which we do not want to do this is the users endpoint,
+	// for which we always fetch all data
+	if (lastSyncDate === undefined && NODE_ENV == "development" && !path.includes('/users')) {
+		lastSyncDate = new Date(syncDate.getTime() - DEV_DAYS_LIMIT * 24 * 60 * 60 * 1000);
+	}
+
 	if (lastSyncDate !== undefined) {
 		params['range[updated_at]'] = `${lastSyncDate.toISOString()},${syncDate.toISOString()}`;
 		console.log(`Fetching data from Intra API updated on path ${path} since ${lastSyncDate.toISOString()}...`);
@@ -95,6 +105,12 @@ export const syncData = async function(api: Fast42, syncDate: Date, lastSyncDate
 };
 
 export const syncDataCB = async function(api: Fast42, syncDate: Date, lastSyncDate: Date | undefined, path: string, params: any, callback: (data: any) => void): Promise<void> {
+	// In development mode we do not want to be stuck fetching too much data,
+	// so we assume a default limit of two years
+	if (lastSyncDate === undefined && NODE_ENV == "development") {
+		lastSyncDate = new Date(syncDate.getTime() - DEV_DAYS_LIMIT * 24 * 60 * 60 * 1000);
+	}
+
 	if (lastSyncDate !== undefined) {
 		if (!path.includes('locations')) {
 			params['range[updated_at]'] = `${lastSyncDate.toISOString()},${syncDate.toISOString()}`;

--- a/src/intra/base.ts
+++ b/src/intra/base.ts
@@ -85,7 +85,7 @@ export const fetchMultiple42ApiPagesCallback = async function(api: Fast42, path:
 
 export const syncData = async function(api: Fast42, syncDate: Date, lastSyncDate: Date | undefined, path: string, params: any): Promise<any[]> {
 	// In development mode we do not want to be stuck fetching too much data,
-	// so we assume a default limit of two years
+	// so we impose a limit based on the DEV_DAYS_LIMIT environment variable.
 	//
 	// The only case in which we do not want to do this is the users endpoint,
 	// for which we always fetch all data
@@ -106,7 +106,7 @@ export const syncData = async function(api: Fast42, syncDate: Date, lastSyncDate
 
 export const syncDataCB = async function(api: Fast42, syncDate: Date, lastSyncDate: Date | undefined, path: string, params: any, callback: (data: any) => void): Promise<void> {
 	// In development mode we do not want to be stuck fetching too much data,
-	// so we assume a default limit of two years
+	// so we impose a limit based on the DEV_DAYS_LIMIT environment variable.
 	if (lastSyncDate === undefined && NODE_ENV == "development") {
 		lastSyncDate = new Date(syncDate.getTime() - DEV_DAYS_LIMIT * 24 * 60 * 60 * 1000);
 	}


### PR DESCRIPTION
This PR adds a limit to the data fetched when the app is running in development mode. Fetching all the historic data is not needed to test things, so it defaults to fetching just the last year's worth of data.

To configure the limit, I've added a `DEV_DAYS_LIMIT` environment variable, with a default in the compose file. If it's not set, I put 365 days as a sensible default. When `NODE_ENV` is set to something other than `development`, no limit is imposed.