### PR TITLE
fix: only set returnTo when not requesting a static file

### DIFF
--- a/src/handlers/middleware.ts
+++ b/src/handlers/middleware.ts
@@ -13,9 +13,12 @@ const checkIfAuthenticated = function(req: Request, res: Response, next: NextFun
 	if (req.isAuthenticated()) {
 		return next();
 	}
-	// Store the path the user was trying to access
-	(req.session as CustomSessionData).returnTo = req.originalUrl;
-	return res.redirect('/login');
+	// Only save the path for return-to if we are not requesting a static resource
+	if (!req.path.match(/^.*\.[^\\]+$/)) {
+		// Store the path the user was trying to access
+		(req.session as CustomSessionData).returnTo = req.originalUrl;
+		return res.redirect('/login');
+	}
 };
 
 export const checkIfStudentOrStaff = async function(req: Request, res: Response, next: NextFunction) {


### PR DESCRIPTION
The redirect feature implemented in 3245ac2 has a small bug where every request to the server leads to an update of the `returnTo` session variable. This means that the browser, when it automatically tries to fetch `/favicon.ico`, causes that to become the path to which the user is returned after logging in. This is not what we want to have happen. (There also is no file with that name right now, so it leads to everyone seeing a 404 immediately after the login callback and having to manually go back to the home page.)

This PR adds an if statement with a quick regex check to the `returnTo` part of `checkIfAuthenticated`. This regex checks whether, after the last slash character in the path, it can find a period followed by one or more other characters. If so, it does not update `returnTo`. This should exempt any stylesheets, images, scripts and icons we may serve.

This is probably not the best or most solid way to solve this problem. I don't know if Express has an easy way of differentiating between "app" paths and file paths, for example. If there is, we should probably just use that instead. For now, though, this does solve the redirect issue.