### PR TITLE
fix: use usual full names in the frontend

### DIFF
--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -34,8 +34,7 @@ export const setupUsersRoutes = function(app: Express, prisma: PrismaClient): vo
 				},
 			},
 			orderBy: [
-				{ first_name: 'asc' },
-				{ last_name: 'asc' },
+				{ usual_full_name: 'asc' }
 			],
 		});
 
@@ -67,8 +66,7 @@ export const setupUsersRoutes = function(app: Express, prisma: PrismaClient): vo
 				},
 			},
 			orderBy: [
-				{ first_name: 'asc' },
-				{ last_name: 'asc' },
+				{ usual_full_name: 'asc' }
 			],
 		});
 
@@ -130,8 +128,7 @@ export const setupUsersRoutes = function(app: Express, prisma: PrismaClient): vo
 				},
 			},
 			orderBy: [
-				{ first_name: 'asc' },
-				{ last_name: 'asc' },
+				{ usual_full_name: 'asc' }
 			],
 		});
 

--- a/templates/piscines.njk
+++ b/templates/piscines.njk
@@ -71,7 +71,7 @@ csvDownloadLink.download = `piscine-{{ year }}-{{ month }}-export-${formattedDat
 		<!-- display user information -->
 		<li class="user piscine{{ " dropout" if dropouts[user.login] }}" data-firstname="{{ user.first_name | lower }}" data-lastname="{{ user.last_name | lower }}" data-login="{{ user.login }}" data-lastseen="{{ (user.locations[0].begin_at | timestamp) if user.locations.length > 0 else 0 }}" data-totallogtime="{{ logtimes[user.login].total }}" data-level="{{ user.cursus_users[0].level | formatFloat }}">
 			<div class="basic-info">
-				<div class="name">{{ user.display_name }}</div>
+				<div class="name">{{ user.usual_full_name }}</div>
 				<div class="login" title="User ID {{ user.id }}"><a target="_blank" href="https://profile.intra.42.fr/users/{{ user.login }}/">{{ user.login }}</a></div>
 				<div class="level">{{ user.cursus_users[0].level | formatFloat }}{{ " (dropout)" if dropouts[user.login] }}</div>
 				<img class="picture" src="{{ user.image if user.image else "/images/default.png" }}" loading="lazy" />

--- a/templates/piscines.njk
+++ b/templates/piscines.njk
@@ -69,7 +69,7 @@ csvDownloadLink.download = `piscine-{{ year }}-{{ month }}-export-${formattedDat
 <ul class="userlist piscine">
 	{% for user in users %}
 		<!-- display user information -->
-		<li class="user piscine{{ " dropout" if dropouts[user.login] }}" data-firstname="{{ user.first_name | lower }}" data-lastname="{{ user.last_name | lower }}" data-login="{{ user.login }}" data-lastseen="{{ (user.locations[0].begin_at | timestamp) if user.locations.length > 0 else 0 }}" data-totallogtime="{{ logtimes[user.login].total }}" data-level="{{ user.cursus_users[0].level | formatFloat }}">
+		<li class="user piscine{{ " dropout" if dropouts[user.login] }}" data-firstname="{{ user.usual_first_name | lower }}" data-lastname="{{ user.last_name | lower }}" data-login="{{ user.login }}" data-lastseen="{{ (user.locations[0].begin_at | timestamp) if user.locations.length > 0 else 0 }}" data-totallogtime="{{ logtimes[user.login].total }}" data-level="{{ user.cursus_users[0].level | formatFloat }}">
 			<div class="basic-info">
 				<div class="name">{{ user.usual_full_name }}</div>
 				<div class="login" title="User ID {{ user.id }}"><a target="_blank" href="https://profile.intra.42.fr/users/{{ user.login }}/">{{ user.login }}</a></div>

--- a/templates/users.njk
+++ b/templates/users.njk
@@ -29,7 +29,7 @@
 	{% for user in users %}
 		<!-- display user information -->
 		<li class="user {{ user.cursus_users[0] | markDropout }}">
-			<div class="name">{{ user.display_name }}</div>
+			<div class="name">{{ user.usual_full_name }}</div>
 			<div class="login" title="User ID {{ user.id }}"><a target="_blank" href="https://profile.intra.42.fr/users/{{ user.login }}/">{{ user.login }}</a></div>
 			<div class="pool">{{ user.pool_month }} {{ user.pool_year}}</div>
 			<img class="picture" src="{{ user.image if user.image else "/images/default.png" }}" loading="lazy" />


### PR DESCRIPTION
This PR changes the frontend to sort by and display the `usual_full_name` field instead of the `display_name` field, because as it turns out, that's the one that actually takes custom set names into account. 42 moment.

Side note, please test this locally. My limited dataset includes the most recent piscine and that one checks out, but I also edited the other user views and the piscine overview pages, which I can't access or preview without a full student record in my local database.