### PR TITLE
fix(intra): refresh ongoing regular-cursus levels to catch silent Intra recomputes

### DIFF
--- a/src/intra/cursus.ts
+++ b/src/intra/cursus.ts
@@ -290,10 +290,10 @@ export const syncCursus = async function(api: Fast42, syncDate: Date): Promise<v
 
 	// Same workaround applies to common-core cursus_users: silent server-side
 	// recomputes of `level` mean the incremental `filter[updated_at]` pull misses them.
-	// We do NOT delete missing rows here: a common-core student dropping out of
-	// the curriculum is rare, and Intra may temporarily omit a row for unrelated
-	// reasons; better to leave the existing record in place than to delete it.
-	await refreshOngoingCursusLevels(api, syncDate, REGULAR_CURSUS_IDS, { deleteMissing: false });
+	// Delete missing rows here too: when an applicant signs up for the Common Core
+	// through Apply and then unregisters, Intra deletes the cursus_user, so CodamHero
+	// should drop it as well.
+	await refreshOngoingCursusLevels(api, syncDate, REGULAR_CURSUS_IDS, { deleteMissing: true });
 
 	// Mark synchronization as complete by updating the last_synced_at field
 	await prisma.synchronization.upsert({

--- a/src/intra/cursus.ts
+++ b/src/intra/cursus.ts
@@ -131,6 +131,92 @@ const setupCursuses = async function(): Promise<void> {
 	// });
 }
 
+/**
+ * Re-fetch level/grade from Intra for all currently-ongoing cursus_users in the
+ * given cursus ids, bypassing the incremental updated_at filter.
+ *
+ * Why: Intra recomputes `cursus_users.level` server-side as a side-effect of
+ * project_user / scale_team events, but the recompute does NOT reliably bump
+ * `cursus_users.updated_at`. This means the normal incremental sync
+ * (`filter[updated_at]`) misses level changes, and the local DB freezes at the
+ * value from the last event that *did* happen to touch the timestamp.
+ *
+ * "Ongoing" = begin_at <= syncDate AND (end_at IS NULL OR end_at >= syncDate).
+ * This covers both piscine cursus_users (end_at always set) and common-core
+ * cursus_users (end_at typically NULL until graduation/alumnization).
+ *
+ * @param api          Fast42 instance.
+ * @param syncDate     Current sync timestamp.
+ * @param cursusIds    Cursus IDs to refresh (e.g. PISCINE_CURSUS_IDS or REGULAR_CURSUS_IDS).
+ * @param opts.deleteMissing
+ *                     If true, cursus_users that the API no longer returns are
+ *                     deleted from the local DB (used for piscines, where a
+ *                     pisciner can unregister via Apply). For regular cursuses
+ *                     this should be false: silently dropping a row because the
+ *                     API briefly omitted it is too risky.
+ */
+export const refreshOngoingCursusLevels = async function(
+	api: Fast42,
+	syncDate: Date,
+	cursusIds: number[],
+	opts: { deleteMissing: boolean },
+): Promise<void> {
+	if (cursusIds.length === 0) {
+		return;
+	}
+
+	const ongoing = await prisma.cursusUser.findMany({
+		where: {
+			begin_at: { lte: syncDate },
+			OR: [
+				{ end_at: null },
+				{ end_at: { gte: syncDate } },
+			],
+			cursus_id: { in: cursusIds },
+		},
+	});
+
+	if (ongoing.length === 0) {
+		return;
+	}
+
+	// Chunk in batches of 100 to stay within Intra's filter-by-id URL limits.
+	const chunks: typeof ongoing[] = [];
+	for (let i = 0; i < ongoing.length; i += 100) {
+		chunks.push(ongoing.slice(i, i + 100));
+	}
+
+	for (const chunk of chunks) {
+		const fresh = await fetchMultiple42ApiPages(api, `/cursus_users`, {
+			'filter[id]': chunk.map(c => c.id).join(','),
+		});
+
+		for (const cursusUser of fresh) {
+			try {
+				await prisma.cursusUser.update({
+					where: { id: cursusUser.id },
+					data: {
+						level: cursusUser.level,
+						grade: cursusUser.grade ? cursusUser.grade : null,
+						updated_at: new Date(cursusUser.updated_at),
+					},
+				});
+			}
+			catch (err) {
+				console.error(`Error updating cursus_user ${cursusUser.user?.login ?? '?'} - ${cursusUser.cursus?.name ?? '?'}: ${err}`);
+			}
+		}
+
+		if (opts.deleteMissing) {
+			const missing = chunk.filter(c => !fresh.find((f: any) => f.id === c.id));
+			for (const m of missing) {
+				console.warn(`Cursus_user ${m.id} of user ${m.user_id} was not returned by the API. Removing it from the database.`);
+				await prisma.cursusUser.delete({ where: { id: m.id } });
+			}
+		}
+	}
+};
+
 export const syncCursus = async function(api: Fast42, syncDate: Date): Promise<void> {
 	// Make sure cursuses exist in the database for relations
 	await setupCursuses();
@@ -195,63 +281,19 @@ export const syncCursus = async function(api: Fast42, syncDate: Date): Promise<v
 
 	console.log("Checking for ongoing piscine cursuses...");
 
-	// Synchronize each active piscine cursus to fetch the latest levels
-	// These are not included in the updated_at range because they are not updated directly in the database
-	// and instead calculated by the API server-side...
-	const ongoingPiscineCursuses = await prisma.cursusUser.findMany({
-		where: {
-			begin_at: {
-				lte: syncDate,
-			},
-			end_at: {
-				gte: syncDate,
-			},
-			cursus_id: {
-				in: [0].concat(PISCINE_CURSUS_IDS, DISCO_PISCINE_CURSUS_IDS),
-			},
-		},
-	});
+	// Synchronize each active piscine cursus to fetch the latest levels.
+	// These are not included in the updated_at range because the level is recomputed
+	// server-side without bumping cursus_users.updated_at.
+	await refreshOngoingCursusLevels(api, syncDate, PISCINE_CURSUS_IDS.concat(DISCO_PISCINE_CURSUS_IDS), { deleteMissing: true });
 
-	const ongoingPiscineCursusesChunks = [];
-	for (let i = 0; i < ongoingPiscineCursuses.length; i += 100) {
-		ongoingPiscineCursusesChunks.push(ongoingPiscineCursuses.slice(i, i + 100));
-	}
-	// Check each chunk with the API and update the level field if needed
-	for (const chunk of ongoingPiscineCursusesChunks) {
-		const ongoingPiscineCursusesAPI = await fetchMultiple42ApiPages(api, `/cursus_users`, {
-			'filter[id]': chunk.map(cursusUser => cursusUser.id).join(','),
-		});
+	console.log("Checking for ongoing regular (common-core) cursuses...");
 
-		for (const cursusUser of ongoingPiscineCursusesAPI) {
-			try {
-				await prisma.cursusUser.update({
-					where: {
-						id: cursusUser.id,
-					},
-					data: {
-						level: cursusUser.level,
-						grade: cursusUser.grade ? cursusUser.grade : null,
-						updated_at: new Date(cursusUser.updated_at),
-					},
-				});
-			}
-			catch (err) {
-				console.error(`Error updating cursus_user ${cursusUser.user.login} - ${cursusUser.cursus.name}: ${err}`);
-			}
-		}
-
-		// Find the cursus_users that were not returned by the API
-		// This can happen if a pisciner unregistered from the piscine through Apply
-		const missingCursusUsers = chunk.filter(cursusUser => !ongoingPiscineCursusesAPI.find(cursusUserAPI => cursusUserAPI.id === cursusUser.id));
-		for (const missingCursusUser of missingCursusUsers) {
-			console.warn(`Cursus_user ${missingCursusUser.id} of user ${missingCursusUser.user_id} was not returned by the API. Removing it from the database.`);
-			await prisma.cursusUser.delete({
-				where: {
-					id: missingCursusUser.id,
-				},
-			});
-		}
-	}
+	// Same workaround applies to common-core cursus_users: silent server-side
+	// recomputes of `level` mean the incremental `filter[updated_at]` pull misses them.
+	// We do NOT delete missing rows here: a common-core student dropping out of
+	// the curriculum is rare, and Intra may temporarily omit a row for unrelated
+	// reasons; better to leave the existing record in place than to delete it.
+	await refreshOngoingCursusLevels(api, syncDate, REGULAR_CURSUS_IDS, { deleteMissing: false });
 
 	// Mark synchronization as complete by updating the last_synced_at field
 	await prisma.synchronization.upsert({


### PR DESCRIPTION
## What

Extends the existing "force-refetch ongoing cursus_users to catch silent server-side level recomputes" workaround — currently applied only to piscines — to **regular cursuses (`cursus_id` 1 and 21)** as well.

## Why

Intra recomputes `cursus_users.level` server-side as a side-effect of `project_user` / `scale_team` events, but the recompute does **not** reliably bump `cursus_users.updated_at`. Because the incremental sync filters on `updated_at`, those level changes are silently dropped — the local DB freezes at the value from whichever event last happened to also touch the timestamp.

The author already knew this and worked around it for piscines via the loop at the old `src/intra/cursus.ts:L201-L255`, with the explicit comment:

> // These are not included in the updated_at range because they are not updated directly in the database
> // and instead calculated by the API server-side...

…but the same workaround was never extended to common-core. As a result, common-core students can sit at a stale level indefinitely once they hit a "silent" event.

### Real-world reproduction

A Codam 2023 cohort student (cursus 21):

1. Resume retry bumped level to **11.16** — synced OK (event touched `updated_at`).
2. `ft_containers` was later removed from the curriculum — the `project_user` deletion bumped `updated_at`, synced OK.
3. `ft_transcendence` was validated, taking the level to **12.69** on Intra — `updated_at` not bumped, sync missed it.
4. Three more project validations followed — also silent.
5. Hero stayed stuck at **11.16** while Intra showed **12.69**.

## How

1. Extract the piscine force-refetch loop into a reusable `refreshOngoingCursusLevels(api, syncDate, cursusIds, opts)` helper.
2. Tighten the "ongoing" filter to `begin_at <= syncDate AND (end_at IS NULL OR end_at >= syncDate)` so it handles both piscines (`end_at` always set) and common-core (`end_at` typically `NULL` until graduation/alumnization). The old filter `end_at: { gte: syncDate }` would exclude every common-core student.
3. Make the "delete missing rows" behaviour opt-in via `opts.deleteMissing`:
   - **`true`** for piscines (preserves existing behaviour — a pisciner can unregister via Apply, and dropping the row is appropriate there).
   - **`false`** for `REGULAR_CURSUS_IDS`. Silently dropping a common-core row because the API briefly omitted one is too risky.
4. Call the helper for `REGULAR_CURSUS_IDS` after the existing piscine pass.

## Cost

- One extra `/cursus_users?filter[id]=…` round per sync, chunked at 100 ids. For Codam, the ongoing common-core population is roughly the size of one cohort × a few years — a handful of API pages, negligible.
- Logic for piscines is unchanged in behaviour (same query semantics aside from the new `end_at IS NULL` branch, which can't match piscines anyway).

## Notes

- The previous piscine query included `cursus_id: 0` in the `in:` clause; that ID corresponds to no real cursus and has been dropped in the refactor (it never matched anything).
- No schema changes, no migration needed.

## Tested locally

Verified end-to-end with a focused script that seeds one row, writes a fake-stale `level`, runs the new `refreshOngoingCursusLevels(REGULAR_CURSUS_IDS)`, and diffs before/after. Refresh correctly pulls the current Intra value.
