### PR TITLE
fix(clustermap): stop EventSource reload from hijacking navigation in Firefox

### DIFF
--- a/static/js/clustermaps/live.js
+++ b/static/js/clustermaps/live.js
@@ -1,4 +1,14 @@
 function initClustermaps() {
+	// Track whether the page is unloading. Firefox tears down the EventSource
+	// while navigating away and dispatches an `error` event during unload.
+	// Without this guard the error handler below calls window.location.reload(),
+	// which cancels the navigation and snaps the user back to the clustermap
+	// (and makes external links like CONTRIBUTE appear to "just refresh").
+	let isUnloading = false;
+	const markUnloading = function() { isUnloading = true; };
+	window.addEventListener('pagehide', markUnloading);
+	window.addEventListener('beforeunload', markUnloading);
+
 	// Open a Server Side Events stream for all live locations
 	const eventSource = new EventSource('/clustermap/locations/live');
 	// Listen for new locations
@@ -8,6 +18,12 @@ function initClustermaps() {
 		updateClustermap(data);
 	});
 	eventSource.addEventListener('error', function(event) {
+		// Don't react while navigating away, and let EventSource handle its own
+		// automatic reconnection (readyState CONNECTING). Only reload when the
+		// connection has permanently failed (readyState CLOSED).
+		if (isUnloading || eventSource.readyState !== EventSource.CLOSED) {
+			return;
+		}
 		console.error('EventSource failed:', event);
 		window.location.reload();
 	});
@@ -15,6 +31,9 @@ function initClustermaps() {
 		console.log('EventSource opened');
 	});
 	eventSource.addEventListener('close', function(event) {
+		if (isUnloading) {
+			return;
+		}
 		console.warn('EventSource closed:', event);
 		window.location.reload();
 	});


### PR DESCRIPTION
## Problem

On Firefox, while on the live clustermap page, navigating away is broken:

- Typing a different URL (e.g. `nu.nl`) and pressing enter snaps back to the clustermap instead of navigating.
- Clicking external links such as the **CONTRIBUTE** link (to GitHub) appears to "just refresh" the page.

This does not reproduce on Chromium-based browsers.

## Cause

`static/js/clustermaps/live.js` opens a Server-Sent Events stream (`EventSource`) and its `error` handler calls `window.location.reload()` unconditionally.

When the page starts unloading during navigation, Firefox tears down the SSE connection and dispatches an `error` event. The handler then reloads the page, cancelling the in-progress navigation and returning the user to the clustermap. Chromium does not dispatch this error during unload, so the bug is Firefox-only.

## Fix

- Add a `pagehide` / `beforeunload` flag (`isUnloading`) so the reload never fights the browser's own navigation.
- Only reload on a permanent failure (`readyState === EventSource.CLOSED`) instead of on every transient `error`, letting `EventSource` perform its normal automatic reconnection.
- Apply the same unload guard to the `close` handler.

## Testing

- Firefox: from `/clustermap/live`, navigate to an external URL and click the CONTRIBUTE link — both now work as expected.
- Confirmed live location updates still stream and recover after a dropped connection.