### PR TITLE
fix(css): prevent userlist and home grid from shrinking on large displays

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -256,6 +256,9 @@ header #dropdown-toggle-btn {
 	grid-template-columns: repeat(3, 1fr);
 	gap: 24px;
 	word-wrap: break-word;
+	/* Keep the cards a comfortable size on ultra-wide / 4K displays instead
+	   of stretching the 3 columns edge to edge. */
+	max-width: 1600px;
 }
 
 .home-grid .home-grid-container {
@@ -572,13 +575,16 @@ nav a {
 
 .userlist {
 	display: grid;
+	/* Fit as many 360px-min columns as comfortably fit, but cap the overall
+	   width so ultra-wide / 4K displays at 100% OS scale don't explode into
+	   ~10 tiny columns. Centered via the auto side margins. */
 	grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 	grid-auto-rows: 1fr;
 	gap: 8px;
 	list-style-type: none;
 	margin: 8px auto;
 	padding: 0;
-	grid-template-columns: 3;
+	max-width: 1800px;
 }
 
 .userlist.flexiblerows {


### PR DESCRIPTION
The .userlist rule declared grid-template-columns twice, the second being an invalid `grid-template-columns: 3;` (a bare number is not a valid track list) that browsers discard. The effective rule was repeat(auto-fit, minmax(360px, 1fr)) with no width cap, so on ultra-wide and 4K displays at 100% OS scale the list expanded to ~10 tiny columns, making photos and text hard to read. The home grid had the same unbounded-width problem.

Remove the dead invalid declaration and cap both grids' width (userlist 1800px, home grid 1600px, centered) so large screens keep a comfortable, readable card size.